### PR TITLE
add .htaccess file

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,4 +47,7 @@ title = "Support++"
     url = "https://sounds.support-pp.de"
   
 [params]
-  dateFormat =  "02.01.22" 
+  dateform        = "Jan 2, 2006"
+  dateformShort   = "Jan 2"
+  dateformNum     = "2006-01-02"
+  dateformNumTime = "2006-01-02 15:04 -0700"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,6 +3,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   {{ hugo.Generator }}
   {{ $css := "css/bootstrap.min.css" | absURL }}
+  {{ $favicon := "/favicon.ico" | absURL }}
+  <link rel="icon" href="{{$favicon}}" type="image/ico"/>
   <link rel="stylesheet" href="{{ $css }}">
   <link crossorigin="anonymous" media="all" rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Nunito:400,700&amp;subset=latin-ext,vietnamese" />

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -1,0 +1,5 @@
+#remove html file extension-e.g. https://example.com/file.html will become https://example.com/file
+RewriteEngine on 
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}\.html -f
+RewriteRule ^(.*)$ $1.html [NC,L]


### PR DESCRIPTION
So that also old requests for legal stuff like /impressum.html workd,
we add a .htaccess file which removed the extension .html.
Try: https://deploy-preview-15--naughty-carson-d48a36.netlify.app/impressum.html